### PR TITLE
Progressive compilation

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -2,3 +2,5 @@ use Mix.Config
 
 config :asls, builder: AssemblyScriptLS.Server.Build
 config :asls, rpc: AssemblyScriptLS.JsonRpc
+config :asls, runtime: AssemblyScriptLS.Runtime
+config :asls, analysis: AssemblyScriptLS.Analysis

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -2,3 +2,5 @@ use Mix.Config
 
 config :asls, builder: AssemblyScriptLS.Server.Build
 config :asls, rpc: AssemblyScriptLS.JsonRpc
+config :asls, runtime: AssemblyScriptLS.Runtime
+config :asls, analysis: AssemblyScriptLS.Analysis

--- a/config/test.exs
+++ b/config/test.exs
@@ -2,3 +2,5 @@ use Mix.Config
 
 config :asls, builder: AssemblyScriptLS.Server.Build.Mock
 config :asls, rpc: AssemblyScriptLS.JsonRpc.Mock
+config :asls, runtime: AssemblyScriptLS.Runtime.Mock
+config :asls, analysis: AssemblyScriptLS.Analysis.Mock

--- a/lib/asls/analysis.ex
+++ b/lib/asls/analysis.ex
@@ -7,6 +7,8 @@ defmodule AssemblyScriptLS.Analysis do
   alias AssemblyScriptLS.Runtime
   alias AssemblyScriptLS.Diagnostic
 
+  @behaviour AssemblyScriptLS.Analysis.Behaviour
+
   require Logger
 
   @type t :: %__MODULE__{
@@ -30,7 +32,7 @@ defmodule AssemblyScriptLS.Analysis do
     ])
   end
 
-  def diganostics(analysis = %__MODULE__{}, diagnostics) do
+  def diagnostics(analysis = %__MODULE__{}, diagnostics) do
     %{analysis | diagnostics: diagnostics}
   end
 

--- a/lib/asls/analysis.ex
+++ b/lib/asls/analysis.ex
@@ -1,0 +1,75 @@
+# Assume that an analysis can only be
+# a diagnostic analysis. We'll have to amend
+# this once we have other types of analysis like
+# go-to definition or autocompletion.
+
+defmodule AssemblyScriptLS.Analysis do
+  alias AssemblyScriptLS.Runtime
+  alias AssemblyScriptLS.Diagnostic
+
+  require Logger
+
+  @type t :: %__MODULE__{
+    id: String.t,
+    runtime: Runtime.t,
+    task: Task.t,
+    diagnostics: [Diagnostic]
+  }
+  @required_keys [:runtime, :id, :diagnostics]
+  @enforce_keys @required_keys
+
+  defstruct [:runtime, :id, :diagnostics, :task]
+
+  def new(runtime, id) do
+    task = perform(runtime, id)
+    struct!(__MODULE__, [
+      runtime: runtime,
+      id: id,
+      task: task,
+      diagnostics: []
+    ])
+  end
+
+  def diganostics(analysis = %__MODULE__{}, diagnostics) do
+    %{analysis | diagnostics: diagnostics}
+  end
+
+  def cancel(analysis = %__MODULE__{}) do
+    Task.shutdown(analysis.task, :infinity)
+    analysis
+  end
+
+  def running?(analysis = %__MODULE__{}) do
+    Process.alive?(analysis.task.pid)
+  end
+
+  def reenqueue(analysis = %__MODULE__{}) do
+    target = if running?(analysis), do: cancel(analysis), else: analysis
+
+    %{target | task: perform(target.runtime, target.id)}
+  end
+
+  defp perform(rt, id) do
+    # Add a task supervisor
+    task = Task.async(fn -> build(rt, id) end)
+    Logger.debug("Starting build: #{inspect(task.ref)}")
+    task
+  end
+
+  defp build(rt, id) do
+    %Runtime{executable: exec, target: target} = rt
+    path = path_from_uri(id)
+
+    case System.cmd(exec, [path, "--#{target}", "--noEmit"], stderr_to_stdout:  true) do
+      {content, 1} ->
+        Diagnostic.Parser.parse(id, content)
+      _ ->
+        {id, []}
+    end
+  end
+
+  defp path_from_uri(uri) do
+    URI.decode(URI.parse(uri).path)
+  end
+end
+

--- a/lib/asls/analysis.ex
+++ b/lib/asls/analysis.ex
@@ -15,7 +15,7 @@ defmodule AssemblyScriptLS.Analysis do
     id: String.t,
     runtime: Runtime.t,
     task: Task.t,
-    diagnostics: [Diagnostic]
+    diagnostics: [Diagnostic.t]
   }
   @required_keys [:runtime, :id, :diagnostics]
   @enforce_keys @required_keys

--- a/lib/asls/analysis/behaviour.ex
+++ b/lib/asls/analysis/behaviour.ex
@@ -1,0 +1,10 @@
+defmodule AssemblyScriptLS.Analysis.Behaviour do
+  alias AssemblyScriptLS.Runtime
+  alias AssemblyScriptLS.Diagnostic
+
+  @callback new(Runtime.t, String.t) :: Analysis.t
+  @callback diagnostics(Analysis.t, [Diagnostic.t]) :: Analysis.t
+  @callback cancel(Analysis.t) :: Analysis.t
+  @callback running?(Analysis.t) :: boolean()
+  @callback reenqueue(Analysis.t) :: Analysis.t
+end

--- a/lib/asls/runtime.ex
+++ b/lib/asls/runtime.ex
@@ -37,7 +37,7 @@ defmodule AssemblyScriptLS.Runtime do
   defp executable(env) do
     cond do
       File.exists?(@asc_paths.local) ->
-        OK.success(%{env | executable: @asc_paths.local})
+        OK.success(%{env | executable: Path.absname(@asc_paths.local)})
       true ->
         {_, exit} = System.cmd("which", [@asc_paths.global])
         if exit == 0 do

--- a/lib/asls/runtime.ex
+++ b/lib/asls/runtime.ex
@@ -2,6 +2,8 @@ defmodule AssemblyScriptLS.Runtime do
   require OK
   use OK.Pipe
 
+  @behaviour AssemblyScriptLS.Runtime.Behaviour
+
   @asc_paths %{local: "./node_modules/.bin/asc", global: "asc"}
   @config_file_path "asconfig.json"
   @type t :: %__MODULE__{

--- a/lib/asls/runtime/behaviour.ex
+++ b/lib/asls/runtime/behaviour.ex
@@ -1,0 +1,3 @@
+defmodule AssemblyScriptLS.Runtime.Behaviour do
+  @callback ensure(String.t) :: {:ok, Runtime.t} | {:error, String.t}
+end

--- a/lib/asls/server.ex
+++ b/lib/asls/server.ex
@@ -8,20 +8,19 @@ defmodule AssemblyScriptLS.Server do
     initialized: false,
     root_uri: nil,
     error_codes: %AssemblyScriptLS.Server.ErrorCodes{},
-    build_ref: nil,
-    diagnostics: %{},
-    building?: false,
-    rebuild?: false,
-    documents: [],
+    analyses: %{},
+    runtime: nil
   }
 
-  @builder Application.get_env(:asls, :builder)
   @rpc Application.get_env(:asls, :rpc)
 
   alias AssemblyScriptLS.JsonRpc.Message.{
     Request,
     Notification,
   }
+
+  alias AssemblyScriptLS.Analysis
+  alias AssemblyScriptLS.Runtime
 
   use GenServer
   
@@ -73,7 +72,10 @@ defmodule AssemblyScriptLS.Server do
         }
     end
 
-    {:reply, payload, state}
+    # FIXME: Ensure that runtime dependencies are met
+    # before blindly initializing the server
+    {:ok, rt} = Runtime.ensure(params[:rootUri])
+    {:reply, payload, %{state | runtime: rt}}
   end
 
   @impl true
@@ -82,46 +84,17 @@ defmodule AssemblyScriptLS.Server do
   end
 
   @impl true
-  def handle_call({:notification, %Notification{method: "workspace/didChangeConfiguration"}}, _from, state) do
-    cond do
-      state.building? ->
-        {:reply, :ok, %{state | rebuild?: true}}
-      true ->
-        task = @builder.perform(%{root_uri: state.root_uri})
-        {:reply, :ok, %{state | build_ref: task.ref, building?: true, rebuild?: false}}
-    end
-  end
-
-  @impl true
   def handle_call({:notification, %Notification{method: "textDocument/didOpen"} = req}, from, state) do
     GenServer.reply(from, :ok)
-    uri = req.params[:textDocument].uri
-
-    @rpc.notify("textDocument/publishDiagnostics", %{
-      uri: uri,
-      diagnostics: state.diagnostics[uri] || []
-    })
-
-    state =
-      cond do
-        Enum.find(state.documents, &(&1 == uri)) ->
-          state
-        true ->
-          %{state | documents: [uri | state.documents]}
-      end
-
+    state = enqueue_analysis(state, req.params[:textDocument].uri)
     {:noreply, state}
   end
 
   @impl true
-  def handle_call({:notification, %Notification{method: "textDocument/didSave"} = _req}, _from, state) do
-    cond do
-      state.building? ->
-        {:reply, :ok, %{state | rebuild?: true}}
-      true ->
-        task = @builder.perform(%{root_uri: state.root_uri})
-        {:reply, :ok, %{state | build_ref: task.ref, building?: true, rebuild?: false}}
-    end
+  def handle_call({:notification, %Notification{method: "textDocument/didSave"} = req}, from, state) do
+    GenServer.reply(from, :ok)
+    enqueue_analysis(state, req.params[:textDocument].uri)
+    {:noreply, state}
   end
 
   @impl true
@@ -135,26 +108,23 @@ defmodule AssemblyScriptLS.Server do
   end
 
   @impl true
-  def handle_info({_ref, payload = %{}}, state) do
-    for doc <- state.documents do
-      @rpc.notify("textDocument/publishDiagnostics", %{
-        uri: doc,
-        diagnostics: payload[doc] || [],
-      })
-    end
+  def handle_info({_ref, {uri, payload}}, state) do
+    @rpc.notify("textDocument/publishDiagnostics", %{
+      uri: uri,
+      diagnostics: payload
+    })
 
-    {:noreply, %{state | diagnostics: payload}}
+    analysis = state.analyses[uri]
+               |> Analysis.diganostics(payload)
+
+    state = %{state | analyses: Map.put(state.analyses, uri, analysis)}
+
+    {:noreply, state}
   end
 
   @impl true
   def handle_info({:DOWN, _, _, _, _}, state) do
-    cond do
-      state.rebuild? ->
-        task = @builder.perform(%{root_uri: state.root_uri})
-        {:noreply, %{state | rebuild?: false, building?: true, build_ref: task.ref}}
-      true ->
-        {:noreply, %{state | building?: false, build_ref: nil}}
-    end
+    {:noreply, state}
   end
 
   @impl true
@@ -172,5 +142,16 @@ defmodule AssemblyScriptLS.Server do
     %{
       name: @name,
     }
+  end
+
+  def enqueue_analysis(state, uri) do
+    analysis = state.analyses[uri]
+    if analysis do
+      analysis = Analysis.reenqueue(analysis)
+      %{state | analyses: Map.put(state.analyses, uri, analysis)}
+    else
+      analysis = Analysis.new(state.runtime, uri)
+      %{state | analyses: Map.put_new(state.analyses, uri, analysis)}
+    end
   end
 end

--- a/lib/asls/server/build.ex
+++ b/lib/asls/server/build.ex
@@ -1,2 +1,0 @@
-defmodule AssemblyScriptLS.Server.Build do
-end

--- a/lib/asls/server/build.ex
+++ b/lib/asls/server/build.ex
@@ -1,22 +1,2 @@
 defmodule AssemblyScriptLS.Server.Build do
-  @behaviour AssemblyScriptLS.Server.Job
-  alias AssemblyScriptLS.Diagnostic
-  require Logger
-
-  @impl true
-  def perform(params) do
-    uri = params[:root_uri]
-    task = Task.async(fn -> build(uri) end)
-    Logger.debug("Starting build: #{inspect(task.ref)}")
-    task
-  end
-
-  defp build(uri) do
-    case System.cmd("npm", ["run", "asbuild"], stderr_to_stdout:  true) do
-      {content, 1} ->
-        Diagnostic.Parser.parse(uri, content)
-      _ ->
-        %{}
-    end
-  end
 end

--- a/lib/asls/server/job.ex
+++ b/lib/asls/server/job.ex
@@ -1,3 +1,0 @@
-defmodule AssemblyScriptLS.Server.Job do
-  @callback perform(map()) :: Task.t()
-end

--- a/mix.lock
+++ b/mix.lock
@@ -1,9 +1,9 @@
 %{
-  "jason": {:hex, :jason, "1.2.1", "12b22825e22f468c02eb3e4b9985f3d0cb8dc40b9bd704730efa11abd2708c44", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
-  "meck": {:hex, :meck, "0.8.13", "ffedb39f99b0b99703b8601c6f17c7f76313ee12de6b646e671e3188401f7866", [:rebar3], [], "hexpm"},
-  "mock": {:hex, :mock, "0.3.6", "e810a91fabc7adf63ab5fdbec5d9d3b492413b8cda5131a2a8aa34b4185eb9b4", [:mix], [{:meck, "~> 0.8.13", [hex: :meck, repo: "hexpm", optional: false]}], "hexpm"},
-  "mox": {:hex, :mox, "1.0.0", "4b3c7005173f47ff30641ba044eb0fe67287743eec9bd9545e37f3002b0a9f8b", [:mix], [], "hexpm"},
-  "nimble_parsec": {:hex, :nimble_parsec, "0.5.3", "def21c10a9ed70ce22754fdeea0810dafd53c2db3219a0cd54cf5526377af1c6", [:mix], [], "hexpm"},
-  "ok": {:hex, :ok, "2.3.0", "0a3d513ec9038504dc5359d44e14fc14ef59179e625563a1a144199cdc3a6d30", [:mix], [], "hexpm"},
-  "optimus": {:hex, :optimus, "0.2.0", "3e868b8bedc723d70189cde715df3ef804524c55b26fb33e89cd0f691f50fe80", [:mix], [], "hexpm"},
+  "jason": {:hex, :jason, "1.2.1", "12b22825e22f468c02eb3e4b9985f3d0cb8dc40b9bd704730efa11abd2708c44", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "b659b8571deedf60f79c5a608e15414085fa141344e2716fbd6988a084b5f993"},
+  "meck": {:hex, :meck, "0.8.13", "ffedb39f99b0b99703b8601c6f17c7f76313ee12de6b646e671e3188401f7866", [:rebar3], [], "hexpm", "d34f013c156db51ad57cc556891b9720e6a1c1df5fe2e15af999c84d6cebeb1a"},
+  "mock": {:hex, :mock, "0.3.6", "e810a91fabc7adf63ab5fdbec5d9d3b492413b8cda5131a2a8aa34b4185eb9b4", [:mix], [{:meck, "~> 0.8.13", [hex: :meck, repo: "hexpm", optional: false]}], "hexpm", "bcf1d0a6826fb5aee01bae3d74474669a3fa8b2df274d094af54a25266a1ebd2"},
+  "mox": {:hex, :mox, "1.0.0", "4b3c7005173f47ff30641ba044eb0fe67287743eec9bd9545e37f3002b0a9f8b", [:mix], [], "hexpm", "201b0a20b7abdaaab083e9cf97884950f8a30a1350a1da403b3145e213c6f4df"},
+  "nimble_parsec": {:hex, :nimble_parsec, "0.5.3", "def21c10a9ed70ce22754fdeea0810dafd53c2db3219a0cd54cf5526377af1c6", [:mix], [], "hexpm", "589b5af56f4afca65217a1f3eb3fee7e79b09c40c742fddc1c312b3ac0b3399f"},
+  "ok": {:hex, :ok, "2.3.0", "0a3d513ec9038504dc5359d44e14fc14ef59179e625563a1a144199cdc3a6d30", [:mix], [], "hexpm", "f0347b3f8f115bf347c704184b33cf084f2943771273f2b98a3707a5fa43c4d5"},
+  "optimus": {:hex, :optimus, "0.2.0", "3e868b8bedc723d70189cde715df3ef804524c55b26fb33e89cd0f691f50fe80", [:mix], [], "hexpm", "95bcbf228d4ba67283747629087cc3650b10d24390e4ea533b0a64ca278c181c"},
 }

--- a/test/asls/analysis_test.exs
+++ b/test/asls/analysis_test.exs
@@ -1,0 +1,67 @@
+defmodule AssemblyScriptLS.AnalysisTest do
+  alias AssemblyScriptLS.Runtime
+  alias AssemblyScriptLS.Analysis
+
+  use ExUnit.Case, async: true
+
+  setup _ do
+    Process.flag(:trap_exit, true)
+
+    rt = %Runtime{
+      root_uri: "./",
+      executable: "cli",
+      target: "debug",
+    }
+    id = "foo/bar.ts"
+    analysis = Analysis.new(rt, id)
+
+    [analysis: analysis, rt: rt, id: id]
+  end
+
+  describe "new/2" do
+    test "creates a new analysis and enqueues a new task", %{analysis: analysis, rt: rt, id: id} do
+      assert analysis.runtime == rt
+      assert analysis.id == id
+      assert analysis.diagnostics == []
+      assert analysis.task.ref
+    end
+  end
+
+  describe "diagnostics/1" do
+    test "sets the diagnostics for an analysis", %{analysis: analysis} do
+      analysis = Analysis.diagnostics(analysis, [1])
+      assert length(analysis.diagnostics) == 1
+    end
+  end
+
+  describe "cancel/1" do
+    test "calls Task.shutdown/2 on the analysis task", %{analysis: analysis} do
+      Process.monitor(analysis.task.pid)
+      Analysis.cancel(analysis)
+      assert_receive {:DOWN, _, _, _, :shutdown}
+    end
+  end
+
+  describe "running?/1" do
+    test "returns true if the process is alive", %{analysis: analysis} do
+      assert Analysis.running?(analysis)
+    end
+
+    test "returns false if the process is not alive", %{analysis: analysis} do
+      running? =
+        Analysis.cancel(analysis)
+        |> Analysis.running?
+
+      refute running?
+    end
+  end
+
+  describe "reenqueue/1" do
+    test "cancels the current task and starts a new one", %{analysis: analysis} do
+      current_ref = analysis.task.ref
+      analysis = Analysis.reenqueue(analysis)
+      new_ref = analysis.task.ref
+      assert current_ref != new_ref
+    end
+  end
+end

--- a/test/asls/diagnostic/parser_test.exs
+++ b/test/asls/diagnostic/parser_test.exs
@@ -50,11 +50,11 @@ defmodule AssemblyScriptLS.Diagnostic.ParserTest do
       npm ERR!     /Users/saulecabrera/.npm/_logs/2020-06-11T13_35_22_042Z-debug.log
     """
     
-    result = Parser.parse("foo/bar", output)
+    result = Parser.parse("foo/bar/assembly/index.asc", output)
 
-    diagnostics = result["foo/bar/assembly/index.asc"]
+    {"foo/bar/assembly/index.asc", diagnostics} = result
     assert length(diagnostics) == 2
-    assert hd(diagnostics) == %AssemblyScriptLS.Diagnostic{
+    assert hd(tl(diagnostics)) == %AssemblyScriptLS.Diagnostic{
       code: "TS2304",
       message: "Cannot find name 'return5'.",
       range: %AssemblyScriptLS.Diagnostic.Range{
@@ -68,8 +68,8 @@ defmodule AssemblyScriptLS.Diagnostic.ParserTest do
       severity: 1,
       source: "AssemblyScript Language Server",
     }
-    
-    assert hd(tl(diagnostics)) == %AssemblyScriptLS.Diagnostic{
+
+    assert hd(diagnostics) == %AssemblyScriptLS.Diagnostic{
       code: "TS2355",
       message: "A function whose declared type is not 'void' must return a value.",
       range: %AssemblyScriptLS.Diagnostic.Range{
@@ -107,8 +107,8 @@ defmodule AssemblyScriptLS.Diagnostic.ParserTest do
       npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
     """
 
-    result = Parser.parse("foo/bar", output)
-    diagnostics = result["foo/bar/assembly/index.asc"]
+    result = Parser.parse("foo/bar/assembly/index.asc", output)
+    {"foo/bar/assembly/index.asc", diagnostics} = result
     assert length(diagnostics) === 1
     assert hd(diagnostics) == %AssemblyScriptLS.Diagnostic{
       code: "TS2355",
@@ -141,6 +141,6 @@ defmodule AssemblyScriptLS.Diagnostic.ParserTest do
       npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
     """
 
-    assert %{} == Parser.parse("foo/bar", output)
+    assert {"foo/bar", []} == Parser.parse("foo/bar", output)
   end
 end

--- a/test/asls/runtime_test.exs
+++ b/test/asls/runtime_test.exs
@@ -78,7 +78,7 @@ defmodule AssemblyScriptLS.RuntimeTest do
 
       with_mocks([file]) do
         {:ok, env} = Runtime.ensure "root"
-        assert env.executable == "./node_modules/.bin/asc"
+        assert String.contains?(env.executable, "/node_modules/.bin/asc")
         assert env.target == "debug"
         assert env.root_uri == "root"
       end

--- a/test/support/mocks.ex
+++ b/test/support/mocks.ex
@@ -1,2 +1,3 @@
-Mox.defmock(AssemblyScriptLS.Server.Build.Mock, for: AssemblyScriptLS.Server.Job)
 Mox.defmock(AssemblyScriptLS.JsonRpc.Mock, for: AssemblyScriptLS.JsonRpc.Behaviour)
+Mox.defmock(AssemblyScriptLS.Analysis.Mock, for: AssemblyScriptLS.Analysis.Behaviour)
+Mox.defmock(AssemblyScriptLS.Runtime.Mock, for: AssemblyScriptLS.Runtime.Behaviour)


### PR DESCRIPTION
Instead of compiling the whole project on every file change, compile the projects on a per-file basis.
This approach is more efficient.  


Other notable changes:

1. The build module no longer exists, instead, I'm replacing it with a much more robust `Analysis` module
2. Diagnostics are parsed and associated with one file only. 
3. There's no need to track open documents explicitly, when documents are opened they will be analyzed.
4. Analysis can be reused (not doing this now, but will do so in the future)