### PR TITLE
Ensure runtime deps

### DIFF
--- a/lib/asls/runtime.ex
+++ b/lib/asls/runtime.ex
@@ -50,6 +50,14 @@ defmodule AssemblyScriptLS.Runtime do
     end
   end
 
+  def to_string(rt = %__MODULE__{}) do
+    """
+    Project root: #{URI.decode(URI.parse(rt.root_uri).path)};
+    AssemblyScript compiler: #{rt.executable};
+    Compilation target: #{rt.target};
+    """
+  end
+
   defp configuration(env) do
     if File.exists?(@config_file_path) do
       OK.success(env)

--- a/lib/asls/runtime/behaviour.ex
+++ b/lib/asls/runtime/behaviour.ex
@@ -1,3 +1,5 @@
 defmodule AssemblyScriptLS.Runtime.Behaviour do
+  alias AssemblyScriptLS.Runtime
   @callback ensure(String.t) :: {:ok, Runtime.t} | {:error, String.t}
+  @callback to_string(Runtime.t) :: String.t
 end

--- a/test/asls/runtime_test.exs
+++ b/test/asls/runtime_test.exs
@@ -84,4 +84,21 @@ defmodule AssemblyScriptLS.RuntimeTest do
       end
     end
   end
+
+  describe "to_string/1" do
+    test "returns a string representation of the given runtime struct" do
+      exists = fn _-> true end
+      file = {File, [:passthrough], [cd: fn _ -> :ok end, exists?: exists, read!: fn _ -> Jason.encode!(@valid_config_file) end]}
+
+      with_mocks([file]) do
+        {:ok, env} = Runtime.ensure "root"
+        expected = """
+        Project root: root;
+        AssemblyScript compiler: #{env.executable};
+        Compilation target: #{env.target};
+        """
+        assert expected == Runtime.to_string(env)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR ensures that the runtime dependencies of the language server are met prior to declaring it initialized. 

The runtime dependencies consist of:

1. A valid project root
2. A valid `asc` installation (local will be searched first, defaulting to global)
2. A valid asconfig.json file
3. A valid target definition in the asconfig file (the first target will be taken)

If all the criteria above are met, the server will be initialized with a `%Rntime{}` struct holding this information in the state.

If any of the above criteria fails, an error will be surfaced to the developer.